### PR TITLE
v1.3.0

### DIFF
--- a/runblsrv.sh
+++ b/runblsrv.sh
@@ -347,7 +347,7 @@ while getopts "d:qf:i:g:an:lzh" opt; do
 		INSTALL_AS_VERSION=$(echo "$OPTARG" | cut -d, -f2)
 		;;
 	h|?) echo "---===<| Blockland Dedicated Server Script |>===---"
-		echo "version 1.3.0 -- October 12th, 2018 18:30 CDT"
+		echo "version 1.3.0 -- October 12th, 2018 22:19 CDT"
 		echo "TheBlackParrot (BL_ID 18701)"
 		echo "https://github.com/TheBlackParrot/blockland-dedicated-server-launcher"
 		echo ""


### PR DESCRIPTION
* Split up the main installer function so it's easier to manage
* Additional error-y stopping points
* Option to skip interactive prompts on the installer (`-q`)
* Option to install as a different Linux distro (`-s [distro,v]`, e.g. `-s ubuntu,16.04`, or `-s arch`)
* Installing on Manjaro confirmed working via `-s arch` option.